### PR TITLE
Allow developers to pick their Anthropic model

### DIFF
--- a/.github/workflows/suggest_readme_updates.yml
+++ b/.github/workflows/suggest_readme_updates.yml
@@ -14,9 +14,8 @@ jobs:
       # Note: This points to the latest version on main; users should pull a tagged version instead
       # When doing development on a branch, point to the branch
       # The "uses" field doesn't support variables, so we can't use the branch name dynamically
-      - uses: ktrnka/update-your-readme@model-config
+      - uses: ktrnka/update-your-readme@main
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          anthropic-model: "claude-3-5-sonnet-20241022"
           readme-file: README.md
           debug: "true"

--- a/.github/workflows/suggest_readme_updates.yml
+++ b/.github/workflows/suggest_readme_updates.yml
@@ -14,8 +14,9 @@ jobs:
       # Note: This points to the latest version on main; users should pull a tagged version instead
       # When doing development on a branch, point to the branch
       # The "uses" field doesn't support variables, so we can't use the branch name dynamically
-      - uses: ktrnka/update-your-readme@main
+      - uses: ktrnka/update-your-readme@model-config
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          anthropic-model: "claude-3-5-sonnet-20241022"
           readme-file: README.md
           debug: "true"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ This project automatically updates README files based on changes in pull request
 
 - Suggests README updates based on 1) the pull request description 2) the code changes in the PR 3) commit messages
 - Uses LangChain and Anthropic's Claude model for intelligent suggestions
-- Configurable model selection to balance quality vs cost
 - Option to skip README checks for testing purposes
 
 Currently only available for developers of this repo:
@@ -36,8 +35,8 @@ Make sure to set up the `ANTHROPIC_API_KEY` secret in your repository settings. 
 ### Model Configuration
 
 You can specify which Anthropic model to use through the `anthropic-model` input parameter. This allows you to balance between quality and cost:
-- `claude-3-5-sonnet-20240620` (default) - Recommended for best quality
-- `claude-3-haiku-20240307` - Faster and more cost-effective option
+- `claude-3-5-sonnet-20240620` (default) - Recommended for quality
+- `claude-3-5-haiku-latest` - Faster and more cost-effective option. Note that the behavior may change if you use `latest` rather than a specific version
 
 In your repo settings, under Actions > General > Workflow Permissions be sure to check "Allow GitHub Actions to create and approve pull requests" and allow read/write from Github Actions:
 ![Workflow Permissions](workflow_permissions.png)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This project automatically updates README files based on changes in pull request
 
 - Suggests README updates based on 1) the pull request description 2) the code changes in the PR 3) commit messages
 - Uses LangChain and Anthropic's Claude model for intelligent suggestions
+- Configurable model selection to balance quality vs cost
 - Option to skip README checks for testing purposes
 
 Currently only available for developers of this repo:
@@ -26,10 +27,17 @@ To use this action in your GitHub workflow, add the following step to your `.git
   with:
     anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
     readme-file: README.md
+    anthropic-model: "claude-3-5-sonnet-20240620"  # Optional: Choose your preferred Claude model
 ```
 See `.github/workflows/suggest_readme_updates.yml` for an example.
 
 Make sure to set up the `ANTHROPIC_API_KEY` secret in your repository settings. Note: The Action will not work on PRs from forks because this secret isn't available on workflows for those PRs.
+
+### Model Configuration
+
+You can specify which Anthropic model to use through the `anthropic-model` input parameter. This allows you to balance between quality and cost:
+- `claude-3-5-sonnet-20240620` (default) - Recommended for best quality
+- `claude-3-haiku-20240307` - Faster and more cost-effective option
 
 In your repo settings, under Actions > General > Workflow Permissions be sure to check "Allow GitHub Actions to create and approve pull requests" and allow read/write from Github Actions:
 ![Workflow Permissions](workflow_permissions.png)

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,9 @@ inputs:
   anthropic-api-key:
     description: 'Anthropic API Key (we use their LLM APIs to generate the README updates).'
     required: true
+  anthropic-model:
+    description: 'Anthropic model to use. You can change to a Haiku model to reduce API costs.'
+    default: 'claude-3-5-sonnet-20240620'
   readme-file:
     description: 'The path to the README file to update.'
     required: true
@@ -81,6 +84,7 @@ runs:
         --repository ${{ github.repository }} \
         --pr ${{ github.event.pull_request.number }} \
         --readme ${{ github.workspace }}/${{ inputs.readme-file }} \
+        --model ${{ inputs.anthropic-model }} \
         --output-format github \
         >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT

--- a/src/main.py
+++ b/src/main.py
@@ -235,6 +235,7 @@ def review_pull_request(
         return result
     except ValidationError as e:
         if tries_remaining > 1:
+            # BUG? If this happens, and we're piping stdout to a file to parse the output it may break Github's output parsing
             print("Validation error, trying again")
             return review_pull_request(repo, pr, tries_remaining - 1)
         else:

--- a/src/main.py
+++ b/src/main.py
@@ -247,6 +247,7 @@ if __name__ == "__main__":
     parser.add_argument("--readme", type=str, required=True, help="README file")
     parser.add_argument("--pr", type=int, required=True, help="Pull request number")
     parser.add_argument("--feedback", type=str, help="User feedback for LLM")
+    parser.add_argument("--model", type=str, default="claude-3-5-sonnet-20240620", help="Anthropic model to use")
     parser.add_argument(
         "--output-format",
         type=str,

--- a/src/main.py
+++ b/src/main.py
@@ -207,7 +207,7 @@ def get_model(model_name: str) -> ChatAnthropic:
         warnings.filterwarnings("ignore", category=UserWarning)
 
         # 3.5 models have a max_tokens of 8192, while 3.0 models have a max_tokens of 4096
-        max_tokens = 8192 if model_name.startswith("claude-3-5-") in model_name else 4096
+        max_tokens = 8192 if model_name.startswith("claude-3-5-") else 4096
 
         return ChatAnthropic(
             model=model_name,


### PR DESCRIPTION
This will allow the user to control quality vs cost better. The other closely-related change sets max_tokens based on the model name.

Note that this only applies to the main action, which is exported to marketplace in action.yml. It does not apply to the feedback action yet, because that is not available from marketplace.