### PR TITLE
Redesign the LLM provider to be Github Models, which doesn't require any additional API key

### DIFF
--- a/.github/workflows/readme_feedback.yml
+++ b/.github/workflows/readme_feedback.yml
@@ -51,7 +51,6 @@ jobs:
         id: update-readme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          API_KEY: ${{ secrets.API_KEY }}
         run: |
           uv run python src/main.py --repository ${{ github.repository }} --pr ${{ steps.prs.outputs.original_num }} --readme README.md --feedback "${{ github.event.comment.body }}" --output-format github >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT

--- a/.github/workflows/suggest_readme_updates.yml
+++ b/.github/workflows/suggest_readme_updates.yml
@@ -14,7 +14,7 @@ jobs:
       # Note: This points to the latest version on main; users should pull a tagged version instead
       # When doing development on a branch, point to the branch
       # The "uses" field doesn't support variables, so we can't use the branch name dynamically
-      - uses: ktrnka/update-your-readme@main
+      - uses: ktrnka/update-your-readme@github-models-refactor
         with:
           model-provider: "openai"
           model: gpt-4o-mini-2024-07-18

--- a/.github/workflows/suggest_readme_updates.yml
+++ b/.github/workflows/suggest_readme_updates.yml
@@ -16,8 +16,6 @@ jobs:
       # The "uses" field doesn't support variables, so we can't use the branch name dynamically
       - uses: ktrnka/update-your-readme@github-models-refactor
         with:
-          model-provider: "openai"
-          model: gpt-4o-mini-2024-07-18
-          api-key: ${{ secrets.OPENAI_API_KEY }}
+          model: gpt-4o
           readme-file: README.md
           debug: "true"

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,8 @@
 # Github Models
 
+Dealbreaker:
+Currently, the GITHUB_TOKEN associated with the action run doesn't have permissions to Github Models and there's no way to add those permissions. You can use a personal access token but to do so, you need the user to create one and add it to their secrets.
+
 - To use structured output, you need to override the API version
 - To use o1, you need to override it to a newer one
 - gpt4o and gpt4o-mini work with structured output. No other models work with it that I've tried. They give back different errors

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,5 +1,19 @@
+# Github Models
+
+- To use structured output, you need to override the API version
+- To use o1, you need to override it to a newer one
+- gpt4o and gpt4o-mini work with structured output. No other models work with it that I've tried. They give back different errors
+- The o1 family doesn't support the `system` message so the input needs to be prepared differently for the o1 family
+- There's a helpful field showing whether the generation hit the length limit
+- The schema has some weird issues
+
+## TODO
+
+- Code that inspects a repo and builds an evaluation set from the repo by seeing which auto-PRs were accepted or rejected
+- More-flexible wrapper so that we can try out the o1 family
 
 
+# Old
 ```suggestion
 langchain = "*"
 ```

--- a/NOTES.md
+++ b/NOTES.md
@@ -30,3 +30,21 @@ https://github.com/marketplace/actions/create-pull-request
 - DVC: This is RST not MD so the code fails to find it in the first place.
 - sklearn: Same
 - Pandas: Counter({'no_update': 9, 'ValidationError': 1, 'should_update': 1}). The one suggested update looks a bit more extensive than I'd like.
+
+
+
+## FGithub errors
+# For o1-mini, it returns this error:
+# HttpResponseError: (unsupported_value) Unsupported value: 'messages[0].role' does not support 'system' with this model.
+# Code: unsupported_value
+# Message: Unsupported value: 'messages[0].role' does not support 'system' with this model.
+
+# o1 (first try):
+# HttpResponseError: (BadRequest) Model o1 is enabled only for api versions 2024-12-01-preview and later
+# Code: BadRequest
+# Message: Model o1 is enabled only for api versions 2024-12-01-preview and later
+
+# o1 (second try)
+# HttpResponseError: (unsupported_value) Unsupported value: 'messages[0].role' does not support 'system' with this model.
+# Code: unsupported_value
+# Message: Unsupported value: 'messages[0].role' does not support 'system' with this model.

--- a/action.yml
+++ b/action.yml
@@ -3,17 +3,10 @@ description: 'Automatically suggest updates to your README based on pull request
 author: 'Keith and Lara'
 
 inputs:
-  model-provider: 
-    description: 'Model provider to use. (anthropic or openai)'
-    required: true
-    default: 'anthropic'
-  api-key:
-    description: 'API Key for the specified model provider.'
-    required: true
   model:
-    description: 'Model to use.'
+    description: 'Github Model to use. See https://docs.github.com/en/github-models for more info'
     required: true
-    default: 'claude-3-5-sonnet-20240620'
+    default: 'gpt-4o-mini'
   readme-file:
     description: 'The path to the README file to update.'
     required: true
@@ -60,14 +53,6 @@ runs:
         echo "Repository path: ${{ github.workspace }}"
         echo "Action path": ${{ github.action_path }}
 
-    # Fail fast if the API key is empty
-    - name: Check API Key
-      if: ${{ inputs.api-key == '' }}
-      shell: bash
-      run: |
-        echo "Error: api-key is required."
-        exit 1
-
     - name: Install uv
       uses: astral-sh/setup-uv@v3
 
@@ -89,14 +74,12 @@ runs:
         --repository ${{ github.repository }} \
         --pr ${{ github.event.pull_request.number }} \
         --readme ${{ github.workspace }}/${{ inputs.readme-file }} \
-        --model-provider ${{ inputs.model-provider }} \
         --model ${{ inputs.model }} \
         --output-format github \
         >> $GITHUB_OUTPUT
         cat $GITHUB_OUTPUT
       env:
         GITHUB_TOKEN: ${{ github.token }}
-        API_KEY: ${{ inputs.api-key }}
     
     # Create a new PR with README changes
     - name: Create Pull Request

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ dependencies = [
     "langchain",
     "langchain-anthropic",
     "langchain-openai",
-    "pydantic"
+    "pydantic",
+    "azure-ai-inference"
 ]
 
 [dependency-groups]

--- a/src/main.py
+++ b/src/main.py
@@ -105,9 +105,6 @@ def test_output_validation():
     with pytest.raises(ValidationError):
         ReadmeRecommendation(should_update=True)
 
-    # test that it passes if should_update is False and the updated_readme is missing
-    ReadmeRecommendation(should_update=False, reason="test")
-
     # test that it fails if should_update is True and the updated_readme is missing
     with pytest.raises(ValidationError):
         ReadmeRecommendation(should_update=True, reason="test")
@@ -201,7 +198,7 @@ C) updated_readme: The updated README content (if applicable)
 
 def test_fill_prompt():
     # Basic no-crash test
-    assert "DEFAULT README" in fill_prompt("# DEFAULT README", "# PR STUFF", "")
+    assert "DEFAULT README" in str(fill_prompt("# DEFAULT README", "# PR STUFF", ""))
 
 def get_client() -> ChatCompletionsClient:
     return ChatCompletionsClient(
@@ -211,7 +208,7 @@ def get_client() -> ChatCompletionsClient:
         api_version="2024-12-01-preview",
     )
 
-def get_readme(repo: Repository, pr: PullRequest, use_base_readme=False) -> str:
+def get_readme(repo: Repository.Repository, pr: PullRequest.PullRequest, use_base_readme=False) -> str:
     return repo.get_contents(
             "README.md", ref=pr.base.sha if use_base_readme else pr.head.sha
         ).decoded_content.decode()
@@ -277,6 +274,14 @@ def review_pull_request(
         else:
             raise e
 
+def parse_pr_link(github_client: Github, url: str) -> tuple[Repository.Repository, PullRequest.PullRequest]:
+    # TODO: Improve this code to be more robust
+    repo_name = '/'.join(url.split('/')[-4:-2])
+    pr_number = int(url.split('/')[-1])
+
+    repo = github_client.get_repo(repo_name)
+    pull_request = repo.get_pull(pr_number)
+    return repo, pull_request
 
 if __name__ == "__main__":
     parser = ArgumentParser()

--- a/src/main.py
+++ b/src/main.py
@@ -28,6 +28,8 @@ def pull_request_to_markdown(pr: PullRequest, excluded_diff_types={"ipynb"}) -> 
     for commit in pr.get_commits():
         text += f"- {commit.commit.message}\n"
 
+    print()
+
     for file in pr.get_files():
         patch = "Can't render patch."
         if file.patch and file.filename.split(".")[-1] not in excluded_diff_types:

--- a/src/main.py
+++ b/src/main.py
@@ -205,7 +205,7 @@ def get_client() -> ChatCompletionsClient:
         endpoint="https://models.inference.ai.azure.com",
         credential=AzureKeyCredential(os.environ["GITHUB_TOKEN"]),
         # Needed for structured output
-        api_version="2024-12-01-preview",
+        api_version="2024-10-01-preview",
     )
 
 def get_readme(repo: Repository.Repository, pr: PullRequest.PullRequest, use_base_readme=False) -> str:

--- a/src/poc_github_models.ipynb
+++ b/src/poc_github_models.ipynb
@@ -1,0 +1,635 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Github Models\n",
+    "\n",
+    "This notebook is for testing the Github model APIs to get a sense of any limitations before redoing the implementation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from azure.ai.inference import ChatCompletionsClient\n",
+    "from azure.ai.inference.models import SystemMessage, UserMessage, JsonSchemaFormat\n",
+    "from azure.core.credentials import AzureKeyCredential\n",
+    "\n",
+    "client = ChatCompletionsClient(\n",
+    "    endpoint=\"https://models.inference.ai.azure.com\",\n",
+    "    credential=AzureKeyCredential(os.environ[\"GITHUB_TOKEN\"]),\n",
+    "    # Needed for structured output\n",
+    "    api_version=\"2024-08-01-preview\",\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models_to_try = [\n",
+    "    \"Llama-3.3-70B-Instruct\",\n",
+    "    \"Meta-Llama-3.1-405B-Instruct\",\n",
+    "    \"gpt-4o\",\n",
+    "    \"gpt-4o-mini\",\n",
+    "    \"o1-mini\",\n",
+    "    \"Phi-3.5-MoE-instruct\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 49,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Certainly! Machine learning (ML) is a subset of artificial intelligence (AI) that focuses on the development of algorithms and statistical models that enable computers to perform tasks without explicit instructions. Instead, they learn from data and improve their performance over time. Here are the basics:\n",
+      "\n",
+      "### Key Concepts\n",
+      "\n",
+      "1. **Data**: The foundation of machine learning. Data can be structured (like tables in a database) or unstructured (like images, text, or audio). The quality and quantity of data significantly impact the performance of ML models.\n",
+      "\n",
+      "2. **Features**: These are individual measurable properties or characteristics of the data. In a dataset, features are the input variables used to make predictions.\n",
+      "\n",
+      "3. **Labels**: In supervised learning, labels are the output or target variable that the model is trying to predict. For example, in a dataset predicting house prices, the price would be the label.\n",
+      "\n",
+      "4. **Training and Testing**: The dataset is typically split into two parts:\n",
+      "   - **Training Set**: Used to train the model.\n",
+      "   - **Testing Set**: Used to evaluate the model's performance on unseen data.\n",
+      "\n",
+      "5. **Algorithms**: These are the methods used to learn from data. Common types of algorithms include:\n",
+      "   - **Supervised Learning**: The model is trained on labeled data. Examples include regression (predicting continuous values) and classification (predicting discrete categories).\n",
+      "   - **Unsupervised Learning**: The model is trained on unlabeled data to find patterns or groupings. Examples include clustering and dimensionality reduction.\n",
+      "   - **Reinforcement Learning**: The model learns by interacting with an environment and receiving feedback in the form of rewards or penalties.\n",
+      "\n",
+      "6. **Model**: A mathematical representation of a process that is trained on data. Once trained, the model can make predictions or decisions based on new input data.\n",
+      "\n",
+      "7. **Overfitting and Underfitting**:\n",
+      "   - **Overfitting**: When a model learns the training data too well, including noise and outliers, leading to poor performance on new data.\n",
+      "   - **Underfitting**: When a model is too simple to capture the underlying patterns in the data, resulting in poor performance on both training and testing data.\n",
+      "\n",
+      "8. **Evaluation Metrics**: These are used to assess the performance of a model. Common metrics include accuracy, precision, recall, F1 score, and mean squared error, depending on the type of problem (classification or regression).\n",
+      "\n",
+      "### Steps in a Machine Learning Project\n",
+      "\n",
+      "1. **Define the Problem**: Clearly outline what you want to achieve.\n",
+      "2. **Collect Data**: Gather relevant data that can help solve the problem.\n",
+      "3. **Preprocess Data**: Clean and prepare the data for analysis, which may include handling missing values, normalizing, or encoding categorical variables.\n",
+      "4. **Choose a Model**: Select an appropriate algorithm based on the problem type.\n",
+      "5. **Train the Model**: Use the training data to teach the model.\n",
+      "6. **Evaluate the Model**: Test the model on the testing set and use evaluation metrics to assess its performance.\n",
+      "7. **Tune Hyperparameters**: Adjust the model's parameters to improve performance.\n",
+      "8. **Deploy the Model**: Implement the model in a real-world application.\n",
+      "9. **Monitor and Maintain**: Continuously monitor the model's performance and update it as necessary.\n",
+      "\n",
+      "### Applications of Machine Learning\n",
+      "\n",
+      "Machine learning is used in various fields, including:\n",
+      "- **Healthcare**: Predicting disease outbreaks, diagnosing conditions, and personalizing treatment plans.\n",
+      "- **Finance**: Fraud detection, credit scoring, and algorithmic trading.\n",
+      "- **Marketing**: Customer segmentation, recommendation systems, and sentiment analysis.\n",
+      "- **Autonomous Vehicles**: Object detection, navigation, and decision-making.\n",
+      "\n",
+      "In summary, machine learning is a powerful tool that enables computers to learn from data and make predictions or decisions, with applications across numerous domains.\n"
+     ]
+    }
+   ],
+   "source": [
+    "response = client.complete(\n",
+    "    messages=[\n",
+    "        SystemMessage(content=\"\"\"\"\"\"),\n",
+    "        UserMessage(content=\"Can you explain the basics of machine learning?\"),\n",
+    "    ],\n",
+    "    model=\"gpt-4o-mini\",\n",
+    "    temperature=0.2,\n",
+    "    max_tokens=2048,\n",
+    "    top_p=0.1\n",
+    ")\n",
+    "\n",
+    "print(response.choices[0].message.content)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "({'role': 'system', 'content': '\\nYou\\'ll review a pull request and determine if the README should be updated, then suggest appropriate changes.\\nThe README should be updated if it contains outdated information or if the pull request introduces major new features that are similar to those currently documented in the README.\\n\\nWhen updating the README, be sure to:\\n* Keep the language timeless. Do not reference \"recent\" or \"recently.\"\\n* Focus on the current state of the project features and requirements.\\n\\n\\n# README Guidelines\\n\\n## Provide a Brief Overview of the Project\\nInclude a brief but informative description of your project\\'s purpose, functionality, and goals. This helps users quickly grasp the value of your project and determine if it\\'s relevant to their needs.\\nExample: A user-friendly weather forecasting app that provides real-time data, daily forecasts, and weather alerts for locations worldwide.\\n\\n## Installation and Setup\\nList Prerequisites and System Requirements\\n\\nClearly outline any prerequisites, such as software dependencies, system requirements, or environment variables, for your project. This helps users determine if they can use your project on their system and prepares them for the installation process.\\n\\nExample:\\n\\n```\\n## Prerequisites\\n- Node.js 14.x or higher\\n- Python 3.8 or higher\\n- Environment variables: OPENAI_API_KEY, ...\\n```\\n\\nStep-by-Step Instructions for Installation and Setup\\n\\nProvide clear, step-by-step instructions for installing and setting up your project. This helps users get started quickly and minimizes potential issues.\\n\\nExample:\\n\\n```\\n## Installation\\ngit clone https://github.com/username/WeatherForecastApp.git\\n\\ncd WeatherForecastApp\\n\\nnpm install\\n\\nnpm start\\n```\\n\\n## Use Markdown for Formatting\\nMarkdown is a lightweight markup language that makes it easy to format and style text. Use headers, lists, tables, and other elements to organize your README and make it visually appealing.\\n\\n## Emphasize Readability and Clarity\\n\\n* Large blocks of text can be challenging to read. Break down large paragraphs into smaller sections or bullet points to improve readability.\\n* Write using clear and concise language to ensure that your README is easily understood by users of varying technical expertise. Avoid using jargon or overly technical language without proper explanation.\\n\\n## Avoid Ephemeral References\\n* Do not include references such as \"recent changes,\" \"recently improved,\" or similar time-based language. The README should be timeless, describing the current state of the project without assuming how new or old a feature is.\\n\\n\\n\\n'}, {'role': 'user', 'content': '\\n# Existing README\\n# DEFAULT README\\n\\n# Pull request changes\\n# PR STUFF\\n\\n# Optional User Feedback about README updates\\n\\n\\n# Task\\nBased on the above information, please provide a structured output indicating:\\nA) should_update: Should the README be updated?\\nB) reason: Why?\\nC) updated_readme: The updated README content (if applicable)\\n'})"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from main import readme_guidelines, ReadmeRecommendation\n",
+    "\n",
+    "def fill_prompt(\n",
+    "    readme: str, pull_request_markdown: str, feedback: str\n",
+    ") -> tuple[SystemMessage, UserMessage]:\n",
+    "    return SystemMessage(\n",
+    "                content=f\"\"\"\n",
+    "You'll review a pull request and determine if the README should be updated, then suggest appropriate changes.\n",
+    "The README should be updated if it contains outdated information or if the pull request introduces major new features that are similar to those currently documented in the README.\n",
+    "\n",
+    "When updating the README, be sure to:\n",
+    "* Keep the language timeless. Do not reference \"recent\" or \"recently.\"\n",
+    "* Focus on the current state of the project features and requirements.\n",
+    "\n",
+    "{readme_guidelines}\n",
+    "\n",
+    "\"\"\"), UserMessage(\n",
+    "                content=f\"\"\"\n",
+    "# Existing README\n",
+    "{readme}\n",
+    "\n",
+    "# Pull request changes\n",
+    "{pull_request_markdown}\n",
+    "\n",
+    "# Optional User Feedback about README updates\n",
+    "{feedback}\n",
+    "\n",
+    "# Task\n",
+    "Based on the above information, please provide a structured output indicating:\n",
+    "A) should_update: Should the README be updated?\n",
+    "B) reason: Why?\n",
+    "C) updated_readme: The updated README content (if applicable)\n",
+    "\"\"\"\n",
+    ")\n",
+    "\n",
+    "fill_prompt(\"# DEFAULT README\", \"# PR STUFF\", \"\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Repository(full_name=\"ktrnka/company-detective\"), PullRequest(title=\"Make sure Google Play scraping respects the num reviews param if poss…\", number=44))"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from github import Github, Repository, PullRequest\n",
+    "\n",
+    "url = \"https://github.com/ktrnka/company-detective/pull/44\"\n",
+    "\n",
+    "g = Github(os.environ[\"GITHUB_TOKEN\"])\n",
+    "\n",
+    "def parse_pr_link(github_client: Github, url: str) -> tuple[Repository, PullRequest]:\n",
+    "    # TODO: Improve this code to be more robust\n",
+    "    repo_name = '/'.join(url.split('/')[-4:-2])\n",
+    "    pr_number = int(url.split('/')[-1])\n",
+    "\n",
+    "    repo = github_client.get_repo(repo_name)\n",
+    "    pull_request = repo.get_pull(pr_number)\n",
+    "    return repo, pull_request\n",
+    "\n",
+    "repo, pr = parse_pr_link(g, url)\n",
+    "repo, pr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "# Company Detective\n",
+      "\n",
+      "This project summarizes publicly available information about a company. It leverages various APIs to gather and analyze data, providing a comprehensive overview of the target company.\n",
+      "\n",
+      "Live site: https://ktrnka.github.io/company-detective\n",
+      "\n",
+      "![System diagram](system_diagram.png)\n",
+      "\n",
+      "## Features\n",
+      "\n",
+      "- Multiple information sources including Crunchbase, news articles, and company websites\n",
+      "- Utilizes AI to analyze and summarize information\n",
+      "- Configured via Airtable\n",
+      "- Google Analytics integration for tracking user interactions and site performance.\n",
+      "\n",
+      "## Prerequisites\n",
+      "\n",
+      "- Python 3.11 or higher\n",
+      "- uv (Astral's Python package installer and resolver)\n",
+      "\n",
+      "## API Keys Required\n",
+      "\n",
+      "This project requires API keys for the following services:\n",
+      "\n",
+      "- OpenAI\n",
+      "- Reddit\n",
+      "- Google Custom Search Engine\n",
+      "- Scrapfly\n",
+      "- AWS\n",
+      "- Langsmith (Optional)\n",
+      "- Crunchbase (via Scrapfly)\n",
+      "- Airtable\n",
+      "\n",
+      "Ensure you have obtained the necessary API keys before proceeding with the setup. The project is designed to handle missing API keys gracefully, but functionality may be limited without them.\n",
+      "\n",
+      "## Installation\n",
+      "\n",
+      "1. Clone the repository:\n",
+      "   ```\n",
+      "   git clone https://github.com/ktrnka/company-detective.git\n",
+      "   cd company-detective\n",
+      "   ```\n",
+      "\n",
+      "2. Install uv (if not already installed):\n",
+      "   ```\n",
+      "   make install-uv\n",
+      "   ```\n",
+      "\n",
+      "3. Install dependencies using uv:\n",
+      "   ```\n",
+      "   make install\n",
+      "   ```\n",
+      "\n",
+      "4. Set up your API keys in a `.env` file in the project root directory.\n",
+      "\n",
+      "## Usage\n",
+      "\n",
+      "The main commands for running the company analysis are:\n",
+      "\n",
+      "1. To refresh company data:\n",
+      "   ```\n",
+      "   make refresh-data\n",
+      "   ```\n",
+      "\n",
+      "2. To build the website with analyzed data:\n",
+      "   ```\n",
+      "   make build-website\n",
+      "   ```\n",
+      "\n",
+      "3. To perform both operations sequentially:\n",
+      "   ```\n",
+      "   make build\n",
+      "   ```\n",
+      "\n",
+      "Note: The default goal for the Makefile is set to `build`, so running `make` without arguments will execute the full build process.\n",
+      "\n",
+      "## Data Sources\n",
+      "\n",
+      "- Crunchbase: Provides detailed company information, funding data, and recent news.\n",
+      "- News Articles: Gathers recent news about the company.\n",
+      "- Company Website: Extracts information directly from the company's official website.\n",
+      "- Reddit: Collects relevant discussions and mentions of the company.\n",
+      "- Glassdoor: Offers employee reviews and sentiment analysis (with improved handling for small companies).\n",
+      "- App Reviews: \n",
+      "  - Google Play Store: Scrapes up to 100 recent reviews.\n",
+      "  - Apple App Store: Scrapes reviews and downsamples to 100 if more are available, ensuring balanced representation with Google Play reviews.\n",
+      "\n",
+      "## Contributing\n",
+      "\n",
+      "Contributions are welcome but first contact Keith for more information on how to contribute, as the repository isn't currently set up for open contributions.\n",
+      "\n",
+      "## Testing\n",
+      "\n",
+      "The project includes automated tests. To run the tests, use:\n",
+      "```\n",
+      "make test\n",
+      "```\n",
+      "\n",
+      "Note that some network-based tests may be skipped to avoid dependencies on external services during CI/CD processes.\n",
+      "\n",
+      "## Development\n",
+      "\n",
+      "To check for dead code, you can use:\n",
+      "```\n",
+      "make vulture\n",
+      "```\n",
+      "\n",
+      "## License\n",
+      "\n",
+      "To be determined. Please contact the repository owner for licensing information.\n",
+      "\n",
+      "## Note\n",
+      "\n",
+      "This project is under active development. Some features or data sources may change or be refactored. Please check for updates regularly.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "def get_readme(repo: Repository, pr: PullRequest, use_base_readme=False) -> str:\n",
+    "    return repo.get_contents(\n",
+    "            \"README.md\", ref=pr.base.sha if use_base_readme else pr.head.sha\n",
+    "        ).decoded_content.decode()\n",
+    "\n",
+    "print(get_readme(*parse_pr_link(g, url)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "## [Make sure Google Play scraping respects the num reviews param if poss…])https://github.com/ktrnka/company-detective/pull/44\n",
+      "Oops I meant to include this in the previous PR\n",
+      "\n",
+      "### Commit Messages\n",
+      "- Make sure Google Play scraping respects the num reviews param if possible\n",
+      "### src/data_sources/app_stores/google_play.py\n",
+      "@@ -134,8 +134,6 @@ def scrape_app_info(app_id: str) -> GooglePlayAppInfo:\n",
+      " \n",
+      " \n",
+      " def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
+      "-    assert num_reviews <= 100, \"Google Play scraping is only implemented to fetch 100 reviews at most\"\n",
+      "-\n",
+      "     review_cache = CollectionCache(cache, ttl=timedelta(days=14))\n",
+      " \n",
+      "     cache_key = f\"google_play_reviews:{app_id}\"\n",
+      "@@ -147,8 +145,8 @@ def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
+      "             lang=\"en\",\n",
+      "             country=\"us\",\n",
+      "             sort=google_play_scraper.Sort.NEWEST,\n",
+      "-            # TODO: See if there's any sort of throttling on this\n",
+      "-            count=num_reviews,\n",
+      "+            # The API only supports fetching up to 100 reviews at a time, though possibly more could be done with the continuation token\n",
+      "+            count=min(num_reviews, 100),\n",
+      "         )\n",
+      "         review_cache.upsert_list(cache_key, \"reviewId\", review_data)\n",
+      "         logger.info(f\"Upserted {len(review_data)} reviews for {app_id}\")\n",
+      "@@ -158,7 +156,13 @@ def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
+      " \n",
+      "     logger.info(f\"Got {len(review_data)} reviews for {app_id}\")\n",
+      " \n",
+      "-    return [GooglePlayReview(**review) for review in review_data]\n",
+      "+    reviews = [GooglePlayReview(**review) for review in review_data]\n",
+      "+    if len(reviews) > num_reviews:\n",
+      "+        # If the cache has more than requested, sort by date and take the most recent\n",
+      "+        reviews = sorted(reviews, key=lambda x: x.at, reverse=True)\n",
+      "+        reviews = reviews[:num_reviews]\n",
+      "+\n",
+      "+    return reviews\n",
+      " \n",
+      " def review_to_markdown(review: GooglePlayReview) -> str:\n",
+      "     # NOTE: The permalink is fake; it's a placeholder for now\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from main import pull_request_to_markdown\n",
+    "\n",
+    "print(pull_request_to_markdown(pr))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from main import ReadmeRecommendation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'description': 'Structured output for the README review task', 'properties': {'should_update': {'description': 'Whether the README should be updated or not', 'title': 'Should Update', 'type': 'boolean'}, 'reason': {'description': 'Reason for the recommendation', 'title': 'Reason', 'type': 'string'}, 'updated_readme': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'description': 'Updated README content, required if should_update is True, otherwise optional', 'title': 'Updated Readme'}}, 'required': ['should_update', 'reason'], 'title': 'ReadmeRecommendation', 'type': 'object'}"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ReadmeRecommendation.model_json_schema()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'BaseModel' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[58], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m readme_content \u001b[38;5;241m=\u001b[39m get_readme(repo, pr)\n\u001b[1;32m      5\u001b[0m pr_content \u001b[38;5;241m=\u001b[39m pull_request_to_markdown(pr)\n\u001b[0;32m----> 7\u001b[0m \u001b[38;5;28;01mclass\u001b[39;00m \u001b[38;5;21;01mReadmeRecommendation2\u001b[39;00m(\u001b[43mBaseModel\u001b[49m):\n\u001b[1;32m      8\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;124;03m    Structured output for the README review task\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m     12\u001b[0m     should_update: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m Field(\n\u001b[1;32m     13\u001b[0m         description\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mWhether the README should be updated or not\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     14\u001b[0m     )\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'BaseModel' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "import json\n",
+    "from typing import Optional\n",
+    "from azure.ai.inference.models import JsonSchemaFormat\n",
+    "from pydantic import BaseModel, Field\n",
+    "\n",
+    "repo, pr = parse_pr_link(g, url)\n",
+    "readme_content = get_readme(repo, pr)\n",
+    "pr_content = pull_request_to_markdown(pr)\n",
+    "\n",
+    "class ReadmeRecommendation2(BaseModel):\n",
+    "    \"\"\"\n",
+    "    Structured output for the README review task\n",
+    "    \"\"\"\n",
+    "\n",
+    "    should_update: bool = Field(\n",
+    "        description=\"Whether the README should be updated or not\"\n",
+    "    )\n",
+    "    reason: str = Field(description=\"Reason for the recommendation\")\n",
+    "    updated_readme: Optional[str] = Field(\n",
+    "        description=\"Updated README content, required if should_update is True, otherwise optional\",\n",
+    "    )\n",
+    "\n",
+    "\n",
+    "response = client.complete(\n",
+    "    messages=fill_prompt(readme_content, pr_content, \"\"),\n",
+    "    model=\"gpt-4o-mini\",\n",
+    "    temperature=0.2,\n",
+    "    # The max on my tier\n",
+    "    max_tokens=4000,\n",
+    "    top_p=0.1,\n",
+    "    response_format=JsonSchemaFormat(\n",
+    "        name=ReadmeRecommendation.__name__,\n",
+    "        schema=ReadmeRecommendation.model_json_schema(),\n",
+    "        description=\"Structured output for recommendations about possible README updates\",\n",
+    "        strict=True\n",
+    "    )\n",
+    ")\n",
+    "\n",
+    "json_response_message = json.loads(response.choices[0].message.content)\n",
+    "\n",
+    "print(response.choices[0].message.content)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'choices': [{'finish_reason': 'length', 'index': 0, 'message': {'content': '{\"description\": \"Structured output for the README review task\", \"properties\": {\"should_update\": {\"description\": \"Whether the README should be updated or not\", \"title\": \"Should Update\", \"type\": \"boolean\"}, \"reason\": {\"description\": \"Reason for the recommendation\", \"title\": \"Reason\", \"type\": \"string\"}, \"updated_readme\": {\"anyOf\": [{\"type\": \"string\"}, {\"type\": \"null\"}], \"default\": null, \"description\": \"Updated README content, required if should_update is True, otherwise optional\", \"title\": \"Updated Readme\"}}, \"required\": [\"should_update\", \"reason\"], \"title\": \"ReadmeRecommendation\", \"type\": \"object\"}\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n \\n\\n\\n\\n\\n \\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n', 'role': 'assistant', 'tool_calls': None}}], 'created': 1736982668, 'id': 'cmpl-00e6457f-2bcd-42c1-bec5-d1f9de115dd6', 'model': 'Llama-3.3-70B-Instruct', 'object': 'chat.completion', 'usage': {'completion_tokens': 4000, 'prompt_tokens': 1924, 'total_tokens': 5924}}"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<class 'azure.ai.inference.models._patch.ChatCompletions'>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "\n",
+    "type(response)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model: Llama-3.3-70B-Instruct\n",
+      "Usage: {'completion_tokens': 4000, 'prompt_tokens': 1924, 'total_tokens': 5924}\n",
+      "Finish reason: CompletionsFinishReason.TOKEN_LIMIT_REACHED\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Things that are useful to check\n",
+    "print(f\"Model: {response.model}\")\n",
+    "print(f\"Usage: {response.usage}\")\n",
+    "\n",
+    "choice = response.choices[0]\n",
+    "print(f\"Finish reason: {choice.finish_reason}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'choices': [{'finish_reason': 'stop', 'index': 0, 'message': {'content': '## Task Output\\n\\nA) **should_update**: No\\nB) **reason**: The pull request introduces a minor change to the Google Play scraping functionality, which does not significantly alter the project\\'s features or requirements. The existing README already documents the project\\'s purpose, functionality, and goals, and the change does not warrant a major update.\\nC) **updated_readme**: Not applicable, as no update is recommended.\\n\\nHowever, it\\'s worth noting that the README could be improved in some areas, such as:\\n\\n* Adding more details about the project\\'s goals and motivations\\n* Providing a clearer explanation of the project\\'s architecture and technical stack\\n* Including more information about the project\\'s testing and development processes\\n* Updating the \"Note\" section to reflect the project\\'s current status and any plans for future development\\n\\nBut these changes are not directly related to the pull request and would require a more comprehensive review of the project\\'s documentation.', 'role': 'assistant', 'tool_calls': None}}], 'created': 1736981525, 'id': 'cmpl-beeaca99-68cf-4666-81bc-137b38fe08b8', 'model': 'Llama-3.3-70B-Instruct', 'object': 'chat.completion', 'usage': {'completion_tokens': 187, 'prompt_tokens': 1763, 'total_tokens': 1950}}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if choice.finish_reason == CompletionFinishReason.STOPPED:\n",
+    "    print(f\"Stop reason: {choice.stop_reason}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/poc_github_models.ipynb
+++ b/src/poc_github_models.ipynb
@@ -11,200 +11,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(Repository(full_name=\"ktrnka/company-detective\"),\n",
+       " PullRequest(title=\"Make sure Google Play scraping respects the num reviews param if poss…\", number=44))"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import os\n",
-    "from azure.ai.inference import ChatCompletionsClient\n",
-    "from azure.ai.inference.models import SystemMessage, UserMessage, JsonSchemaFormat\n",
-    "from azure.core.credentials import AzureKeyCredential\n",
-    "\n",
-    "client = ChatCompletionsClient(\n",
-    "    endpoint=\"https://models.inference.ai.azure.com\",\n",
-    "    credential=AzureKeyCredential(os.environ[\"GITHUB_TOKEN\"]),\n",
-    "    # Needed for structured output\n",
-    "    api_version=\"2024-08-01-preview\",\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "models_to_try = [\n",
-    "    \"Llama-3.3-70B-Instruct\",\n",
-    "    \"Meta-Llama-3.1-405B-Instruct\",\n",
-    "    \"gpt-4o\",\n",
-    "    \"gpt-4o-mini\",\n",
-    "    \"o1-mini\",\n",
-    "    \"Phi-3.5-MoE-instruct\"\n",
-    "]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 49,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Certainly! Machine learning (ML) is a subset of artificial intelligence (AI) that focuses on the development of algorithms and statistical models that enable computers to perform tasks without explicit instructions. Instead, they learn from data and improve their performance over time. Here are the basics:\n",
-      "\n",
-      "### Key Concepts\n",
-      "\n",
-      "1. **Data**: The foundation of machine learning. Data can be structured (like tables in a database) or unstructured (like images, text, or audio). The quality and quantity of data significantly impact the performance of ML models.\n",
-      "\n",
-      "2. **Features**: These are individual measurable properties or characteristics of the data. In a dataset, features are the input variables used to make predictions.\n",
-      "\n",
-      "3. **Labels**: In supervised learning, labels are the output or target variable that the model is trying to predict. For example, in a dataset predicting house prices, the price would be the label.\n",
-      "\n",
-      "4. **Training and Testing**: The dataset is typically split into two parts:\n",
-      "   - **Training Set**: Used to train the model.\n",
-      "   - **Testing Set**: Used to evaluate the model's performance on unseen data.\n",
-      "\n",
-      "5. **Algorithms**: These are the methods used to learn from data. Common types of algorithms include:\n",
-      "   - **Supervised Learning**: The model is trained on labeled data. Examples include regression (predicting continuous values) and classification (predicting discrete categories).\n",
-      "   - **Unsupervised Learning**: The model is trained on unlabeled data to find patterns or groupings. Examples include clustering and dimensionality reduction.\n",
-      "   - **Reinforcement Learning**: The model learns by interacting with an environment and receiving feedback in the form of rewards or penalties.\n",
-      "\n",
-      "6. **Model**: A mathematical representation of a process that is trained on data. Once trained, the model can make predictions or decisions based on new input data.\n",
-      "\n",
-      "7. **Overfitting and Underfitting**:\n",
-      "   - **Overfitting**: When a model learns the training data too well, including noise and outliers, leading to poor performance on new data.\n",
-      "   - **Underfitting**: When a model is too simple to capture the underlying patterns in the data, resulting in poor performance on both training and testing data.\n",
-      "\n",
-      "8. **Evaluation Metrics**: These are used to assess the performance of a model. Common metrics include accuracy, precision, recall, F1 score, and mean squared error, depending on the type of problem (classification or regression).\n",
-      "\n",
-      "### Steps in a Machine Learning Project\n",
-      "\n",
-      "1. **Define the Problem**: Clearly outline what you want to achieve.\n",
-      "2. **Collect Data**: Gather relevant data that can help solve the problem.\n",
-      "3. **Preprocess Data**: Clean and prepare the data for analysis, which may include handling missing values, normalizing, or encoding categorical variables.\n",
-      "4. **Choose a Model**: Select an appropriate algorithm based on the problem type.\n",
-      "5. **Train the Model**: Use the training data to teach the model.\n",
-      "6. **Evaluate the Model**: Test the model on the testing set and use evaluation metrics to assess its performance.\n",
-      "7. **Tune Hyperparameters**: Adjust the model's parameters to improve performance.\n",
-      "8. **Deploy the Model**: Implement the model in a real-world application.\n",
-      "9. **Monitor and Maintain**: Continuously monitor the model's performance and update it as necessary.\n",
-      "\n",
-      "### Applications of Machine Learning\n",
-      "\n",
-      "Machine learning is used in various fields, including:\n",
-      "- **Healthcare**: Predicting disease outbreaks, diagnosing conditions, and personalizing treatment plans.\n",
-      "- **Finance**: Fraud detection, credit scoring, and algorithmic trading.\n",
-      "- **Marketing**: Customer segmentation, recommendation systems, and sentiment analysis.\n",
-      "- **Autonomous Vehicles**: Object detection, navigation, and decision-making.\n",
-      "\n",
-      "In summary, machine learning is a powerful tool that enables computers to learn from data and make predictions or decisions, with applications across numerous domains.\n"
-     ]
-    }
-   ],
-   "source": [
-    "response = client.complete(\n",
-    "    messages=[\n",
-    "        SystemMessage(content=\"\"\"\"\"\"),\n",
-    "        UserMessage(content=\"Can you explain the basics of machine learning?\"),\n",
-    "    ],\n",
-    "    model=\"gpt-4o-mini\",\n",
-    "    temperature=0.2,\n",
-    "    max_tokens=2048,\n",
-    "    top_p=0.1\n",
-    ")\n",
-    "\n",
-    "print(response.choices[0].message.content)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 50,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "({'role': 'system', 'content': '\\nYou\\'ll review a pull request and determine if the README should be updated, then suggest appropriate changes.\\nThe README should be updated if it contains outdated information or if the pull request introduces major new features that are similar to those currently documented in the README.\\n\\nWhen updating the README, be sure to:\\n* Keep the language timeless. Do not reference \"recent\" or \"recently.\"\\n* Focus on the current state of the project features and requirements.\\n\\n\\n# README Guidelines\\n\\n## Provide a Brief Overview of the Project\\nInclude a brief but informative description of your project\\'s purpose, functionality, and goals. This helps users quickly grasp the value of your project and determine if it\\'s relevant to their needs.\\nExample: A user-friendly weather forecasting app that provides real-time data, daily forecasts, and weather alerts for locations worldwide.\\n\\n## Installation and Setup\\nList Prerequisites and System Requirements\\n\\nClearly outline any prerequisites, such as software dependencies, system requirements, or environment variables, for your project. This helps users determine if they can use your project on their system and prepares them for the installation process.\\n\\nExample:\\n\\n```\\n## Prerequisites\\n- Node.js 14.x or higher\\n- Python 3.8 or higher\\n- Environment variables: OPENAI_API_KEY, ...\\n```\\n\\nStep-by-Step Instructions for Installation and Setup\\n\\nProvide clear, step-by-step instructions for installing and setting up your project. This helps users get started quickly and minimizes potential issues.\\n\\nExample:\\n\\n```\\n## Installation\\ngit clone https://github.com/username/WeatherForecastApp.git\\n\\ncd WeatherForecastApp\\n\\nnpm install\\n\\nnpm start\\n```\\n\\n## Use Markdown for Formatting\\nMarkdown is a lightweight markup language that makes it easy to format and style text. Use headers, lists, tables, and other elements to organize your README and make it visually appealing.\\n\\n## Emphasize Readability and Clarity\\n\\n* Large blocks of text can be challenging to read. Break down large paragraphs into smaller sections or bullet points to improve readability.\\n* Write using clear and concise language to ensure that your README is easily understood by users of varying technical expertise. Avoid using jargon or overly technical language without proper explanation.\\n\\n## Avoid Ephemeral References\\n* Do not include references such as \"recent changes,\" \"recently improved,\" or similar time-based language. The README should be timeless, describing the current state of the project without assuming how new or old a feature is.\\n\\n\\n\\n'}, {'role': 'user', 'content': '\\n# Existing README\\n# DEFAULT README\\n\\n# Pull request changes\\n# PR STUFF\\n\\n# Optional User Feedback about README updates\\n\\n\\n# Task\\nBased on the above information, please provide a structured output indicating:\\nA) should_update: Should the README be updated?\\nB) reason: Why?\\nC) updated_readme: The updated README content (if applicable)\\n'})"
-      ]
-     },
-     "execution_count": 50,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from main import readme_guidelines, ReadmeRecommendation\n",
-    "\n",
-    "def fill_prompt(\n",
-    "    readme: str, pull_request_markdown: str, feedback: str\n",
-    ") -> tuple[SystemMessage, UserMessage]:\n",
-    "    return SystemMessage(\n",
-    "                content=f\"\"\"\n",
-    "You'll review a pull request and determine if the README should be updated, then suggest appropriate changes.\n",
-    "The README should be updated if it contains outdated information or if the pull request introduces major new features that are similar to those currently documented in the README.\n",
-    "\n",
-    "When updating the README, be sure to:\n",
-    "* Keep the language timeless. Do not reference \"recent\" or \"recently.\"\n",
-    "* Focus on the current state of the project features and requirements.\n",
-    "\n",
-    "{readme_guidelines}\n",
-    "\n",
-    "\"\"\"), UserMessage(\n",
-    "                content=f\"\"\"\n",
-    "# Existing README\n",
-    "{readme}\n",
-    "\n",
-    "# Pull request changes\n",
-    "{pull_request_markdown}\n",
-    "\n",
-    "# Optional User Feedback about README updates\n",
-    "{feedback}\n",
-    "\n",
-    "# Task\n",
-    "Based on the above information, please provide a structured output indicating:\n",
-    "A) should_update: Should the README be updated?\n",
-    "B) reason: Why?\n",
-    "C) updated_readme: The updated README content (if applicable)\n",
-    "\"\"\"\n",
-    ")\n",
-    "\n",
-    "fill_prompt(\"# DEFAULT README\", \"# PR STUFF\", \"\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 51,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(Repository(full_name=\"ktrnka/company-detective\"), PullRequest(title=\"Make sure Google Play scraping respects the num reviews param if poss…\", number=44))"
-      ]
-     },
-     "execution_count": 51,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from github import Github, Repository, PullRequest\n",
+    "from github import Github\n",
+    "from main import parse_pr_link\n",
     "\n",
     "url = \"https://github.com/ktrnka/company-detective/pull/44\"\n",
     "\n",
     "g = Github(os.environ[\"GITHUB_TOKEN\"])\n",
-    "\n",
-    "def parse_pr_link(github_client: Github, url: str) -> tuple[Repository, PullRequest]:\n",
-    "    # TODO: Improve this code to be more robust\n",
-    "    repo_name = '/'.join(url.split('/')[-4:-2])\n",
-    "    pr_number = int(url.split('/')[-1])\n",
-    "\n",
-    "    repo = github_client.get_repo(repo_name)\n",
-    "    pull_request = repo.get_pull(pr_number)\n",
-    "    return repo, pull_request\n",
     "\n",
     "repo, pr = parse_pr_link(g, url)\n",
     "repo, pr"
@@ -212,290 +41,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "# Company Detective\n",
-      "\n",
-      "This project summarizes publicly available information about a company. It leverages various APIs to gather and analyze data, providing a comprehensive overview of the target company.\n",
-      "\n",
-      "Live site: https://ktrnka.github.io/company-detective\n",
-      "\n",
-      "![System diagram](system_diagram.png)\n",
-      "\n",
-      "## Features\n",
-      "\n",
-      "- Multiple information sources including Crunchbase, news articles, and company websites\n",
-      "- Utilizes AI to analyze and summarize information\n",
-      "- Configured via Airtable\n",
-      "- Google Analytics integration for tracking user interactions and site performance.\n",
-      "\n",
-      "## Prerequisites\n",
-      "\n",
-      "- Python 3.11 or higher\n",
-      "- uv (Astral's Python package installer and resolver)\n",
-      "\n",
-      "## API Keys Required\n",
-      "\n",
-      "This project requires API keys for the following services:\n",
-      "\n",
-      "- OpenAI\n",
-      "- Reddit\n",
-      "- Google Custom Search Engine\n",
-      "- Scrapfly\n",
-      "- AWS\n",
-      "- Langsmith (Optional)\n",
-      "- Crunchbase (via Scrapfly)\n",
-      "- Airtable\n",
-      "\n",
-      "Ensure you have obtained the necessary API keys before proceeding with the setup. The project is designed to handle missing API keys gracefully, but functionality may be limited without them.\n",
-      "\n",
-      "## Installation\n",
-      "\n",
-      "1. Clone the repository:\n",
-      "   ```\n",
-      "   git clone https://github.com/ktrnka/company-detective.git\n",
-      "   cd company-detective\n",
-      "   ```\n",
-      "\n",
-      "2. Install uv (if not already installed):\n",
-      "   ```\n",
-      "   make install-uv\n",
-      "   ```\n",
-      "\n",
-      "3. Install dependencies using uv:\n",
-      "   ```\n",
-      "   make install\n",
-      "   ```\n",
-      "\n",
-      "4. Set up your API keys in a `.env` file in the project root directory.\n",
-      "\n",
-      "## Usage\n",
-      "\n",
-      "The main commands for running the company analysis are:\n",
-      "\n",
-      "1. To refresh company data:\n",
-      "   ```\n",
-      "   make refresh-data\n",
-      "   ```\n",
-      "\n",
-      "2. To build the website with analyzed data:\n",
-      "   ```\n",
-      "   make build-website\n",
-      "   ```\n",
-      "\n",
-      "3. To perform both operations sequentially:\n",
-      "   ```\n",
-      "   make build\n",
-      "   ```\n",
-      "\n",
-      "Note: The default goal for the Makefile is set to `build`, so running `make` without arguments will execute the full build process.\n",
-      "\n",
-      "## Data Sources\n",
-      "\n",
-      "- Crunchbase: Provides detailed company information, funding data, and recent news.\n",
-      "- News Articles: Gathers recent news about the company.\n",
-      "- Company Website: Extracts information directly from the company's official website.\n",
-      "- Reddit: Collects relevant discussions and mentions of the company.\n",
-      "- Glassdoor: Offers employee reviews and sentiment analysis (with improved handling for small companies).\n",
-      "- App Reviews: \n",
-      "  - Google Play Store: Scrapes up to 100 recent reviews.\n",
-      "  - Apple App Store: Scrapes reviews and downsamples to 100 if more are available, ensuring balanced representation with Google Play reviews.\n",
-      "\n",
-      "## Contributing\n",
-      "\n",
-      "Contributions are welcome but first contact Keith for more information on how to contribute, as the repository isn't currently set up for open contributions.\n",
-      "\n",
-      "## Testing\n",
-      "\n",
-      "The project includes automated tests. To run the tests, use:\n",
-      "```\n",
-      "make test\n",
-      "```\n",
-      "\n",
-      "Note that some network-based tests may be skipped to avoid dependencies on external services during CI/CD processes.\n",
-      "\n",
-      "## Development\n",
-      "\n",
-      "To check for dead code, you can use:\n",
-      "```\n",
-      "make vulture\n",
-      "```\n",
-      "\n",
-      "## License\n",
-      "\n",
-      "To be determined. Please contact the repository owner for licensing information.\n",
-      "\n",
-      "## Note\n",
-      "\n",
-      "This project is under active development. Some features or data sources may change or be refactored. Please check for updates regularly.\n",
       "\n"
      ]
-    }
-   ],
-   "source": [
-    "def get_readme(repo: Repository, pr: PullRequest, use_base_readme=False) -> str:\n",
-    "    return repo.get_contents(\n",
-    "            \"README.md\", ref=pr.base.sha if use_base_readme else pr.head.sha\n",
-    "        ).decoded_content.decode()\n",
-    "\n",
-    "print(get_readme(*parse_pr_link(g, url)))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 53,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "## [Make sure Google Play scraping respects the num reviews param if poss…])https://github.com/ktrnka/company-detective/pull/44\n",
-      "Oops I meant to include this in the previous PR\n",
-      "\n",
-      "### Commit Messages\n",
-      "- Make sure Google Play scraping respects the num reviews param if possible\n",
-      "### src/data_sources/app_stores/google_play.py\n",
-      "@@ -134,8 +134,6 @@ def scrape_app_info(app_id: str) -> GooglePlayAppInfo:\n",
-      " \n",
-      " \n",
-      " def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
-      "-    assert num_reviews <= 100, \"Google Play scraping is only implemented to fetch 100 reviews at most\"\n",
-      "-\n",
-      "     review_cache = CollectionCache(cache, ttl=timedelta(days=14))\n",
-      " \n",
-      "     cache_key = f\"google_play_reviews:{app_id}\"\n",
-      "@@ -147,8 +145,8 @@ def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
-      "             lang=\"en\",\n",
-      "             country=\"us\",\n",
-      "             sort=google_play_scraper.Sort.NEWEST,\n",
-      "-            # TODO: See if there's any sort of throttling on this\n",
-      "-            count=num_reviews,\n",
-      "+            # The API only supports fetching up to 100 reviews at a time, though possibly more could be done with the continuation token\n",
-      "+            count=min(num_reviews, 100),\n",
-      "         )\n",
-      "         review_cache.upsert_list(cache_key, \"reviewId\", review_data)\n",
-      "         logger.info(f\"Upserted {len(review_data)} reviews for {app_id}\")\n",
-      "@@ -158,7 +156,13 @@ def scrape_reviews(app_id: str, num_reviews=100) -> List[GooglePlayReview]:\n",
-      " \n",
-      "     logger.info(f\"Got {len(review_data)} reviews for {app_id}\")\n",
-      " \n",
-      "-    return [GooglePlayReview(**review) for review in review_data]\n",
-      "+    reviews = [GooglePlayReview(**review) for review in review_data]\n",
-      "+    if len(reviews) > num_reviews:\n",
-      "+        # If the cache has more than requested, sort by date and take the most recent\n",
-      "+        reviews = sorted(reviews, key=lambda x: x.at, reverse=True)\n",
-      "+        reviews = reviews[:num_reviews]\n",
-      "+\n",
-      "+    return reviews\n",
-      " \n",
-      " def review_to_markdown(review: GooglePlayReview) -> str:\n",
-      "     # NOTE: The permalink is fake; it's a placeholder for now\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "from main import pull_request_to_markdown\n",
-    "\n",
-    "print(pull_request_to_markdown(pr))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 54,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from main import ReadmeRecommendation"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 55,
-   "metadata": {},
-   "outputs": [
+    },
     {
      "data": {
       "text/plain": [
-       "{'description': 'Structured output for the README review task', 'properties': {'should_update': {'description': 'Whether the README should be updated or not', 'title': 'Should Update', 'type': 'boolean'}, 'reason': {'description': 'Reason for the recommendation', 'title': 'Reason', 'type': 'string'}, 'updated_readme': {'anyOf': [{'type': 'string'}, {'type': 'null'}], 'default': None, 'description': 'Updated README content, required if should_update is True, otherwise optional', 'title': 'Updated Readme'}}, 'required': ['should_update', 'reason'], 'title': 'ReadmeRecommendation', 'type': 'object'}"
+       "ReadmeRecommendation(should_update=True, reason='The pull request introduces a change to the Google Play scraping functionality, specifically regarding how the number of reviews is handled. This is a significant update that affects the usage of the application, and the README should reflect this change to ensure users have accurate information about the features and limitations of the project.', updated_readme=\"# Company Detective\\n\\nThis project summarizes publicly available information about a company. It leverages various APIs to gather and analyze data, providing a comprehensive overview of the target company.\\n\\nLive site: https://ktrnka.github.io/company-detective\\n\\n![System diagram](system_diagram.png)\\n\\n## Features\\n\\n- Multiple information sources including Crunchbase, news articles, and company websites\\n- Utilizes AI to analyze and summarize information\\n- Configured via Airtable\\n- Google Analytics integration for tracking user interactions and site performance.\\n\\n## Prerequisites\\n\\n- Python 3.11 or higher\\n- uv (Astral's Python package installer and resolver)\\n\\n## API Keys Required\\n\\nThis project requires API keys for the following services:\\n\\n- OpenAI\\n- Reddit\\n- Google Custom Search Engine\\n- Scrapfly\\n- AWS\\n- Langsmith (Optional)\\n- Crunchbase (via Scrapfly)\\n- Airtable\\n\\nEnsure you have obtained the necessary API keys before proceeding with the setup. The project is designed to handle missing API keys gracefully, but functionality may be limited without them.\\n\\n## Installation\\n\\n1. Clone the repository:\\n   ```\\n   git clone https://github.com/ktrnka/company-detective.git\\n   cd company-detective\\n   ```\\n\\n2. Install uv (if not already installed):\\n   ```\\n   make install-uv\\n   ```\\n\\n3. Install dependencies using uv:\\n   ```\\n   make install\\n   ```\\n\\n4. Set up your API keys in a `.env` file in the project root directory.\\n\\n## Usage\\n\\nThe main commands for running the company analysis are:\\n\\n1. To refresh company data:\\n   ```\\n   make refresh-data\\n   ```\\n\\n2. To build the website with analyzed data:\\n   ```\\n   make build-website\\n   ```\\n\\n3. To perform both operations sequentially:\\n   ```\\n   make build\\n   ```\\n\\nNote: The default goal for the Makefile is set to `build`, so running `make` without arguments will execute the full build process.\\n\\n## Data Sources\\n\\n- Crunchbase: Provides detailed company information, funding data, and recent news.\\n- News Articles: Gathers recent news about the company.\\n- Company Website: Extracts information directly from the company's official website.\\n- Reddit: Collects relevant discussions and mentions of the company.\\n- Glassdoor: Offers employee reviews and sentiment analysis (with improved handling for small companies).\\n- App Reviews: \\n  - Google Play Store: Scrapes up to the specified number of recent reviews, respecting the limit of 100 reviews.\\n  - Apple App Store: Scrapes reviews and downsamples to 100 if more are available, ensuring balanced representation with Google Play reviews.\\n\\n## Contributing\\n\\nContributions are welcome but first contact Keith for more information on how to contribute, as the repository isn't currently set up for open contributions.\\n\\n## Testing\\n\\nThe project includes automated tests. To run the tests, use:\\n```\\nmake test\\n```\\n\\nNote that some network-based tests may be skipped to avoid dependencies on external services during CI/CD processes.\\n\\n## Development\\n\\nTo check for dead code, you can use:\\n```\\nmake vulture\\n```\\n\\n## License\\n\\nTo be determined. Please contact the repository owner for licensing information.\\n\\n## Note\\n\\nThis project is under active development. Some features or data sources may change or be refactored. Please check for updates regularly.\")"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "ReadmeRecommendation.model_json_schema()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 58,
-   "metadata": {},
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'BaseModel' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[58], line 7\u001b[0m\n\u001b[1;32m      4\u001b[0m readme_content \u001b[38;5;241m=\u001b[39m get_readme(repo, pr)\n\u001b[1;32m      5\u001b[0m pr_content \u001b[38;5;241m=\u001b[39m pull_request_to_markdown(pr)\n\u001b[0;32m----> 7\u001b[0m \u001b[38;5;28;01mclass\u001b[39;00m \u001b[38;5;21;01mReadmeRecommendation2\u001b[39;00m(\u001b[43mBaseModel\u001b[49m):\n\u001b[1;32m      8\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m      9\u001b[0m \u001b[38;5;124;03m    Structured output for the README review task\u001b[39;00m\n\u001b[1;32m     10\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m     12\u001b[0m     should_update: \u001b[38;5;28mbool\u001b[39m \u001b[38;5;241m=\u001b[39m Field(\n\u001b[1;32m     13\u001b[0m         description\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mWhether the README should be updated or not\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     14\u001b[0m     )\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'BaseModel' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "import json\n",
-    "from typing import Optional\n",
-    "from azure.ai.inference.models import JsonSchemaFormat\n",
-    "from pydantic import BaseModel, Field\n",
-    "\n",
-    "repo, pr = parse_pr_link(g, url)\n",
-    "readme_content = get_readme(repo, pr)\n",
-    "pr_content = pull_request_to_markdown(pr)\n",
-    "\n",
-    "class ReadmeRecommendation2(BaseModel):\n",
-    "    \"\"\"\n",
-    "    Structured output for the README review task\n",
-    "    \"\"\"\n",
-    "\n",
-    "    should_update: bool = Field(\n",
-    "        description=\"Whether the README should be updated or not\"\n",
-    "    )\n",
-    "    reason: str = Field(description=\"Reason for the recommendation\")\n",
-    "    updated_readme: Optional[str] = Field(\n",
-    "        description=\"Updated README content, required if should_update is True, otherwise optional\",\n",
-    "    )\n",
+    "from main import get_client, review_pull_request\n",
     "\n",
     "\n",
-    "response = client.complete(\n",
-    "    messages=fill_prompt(readme_content, pr_content, \"\"),\n",
-    "    model=\"gpt-4o-mini\",\n",
-    "    temperature=0.2,\n",
-    "    # The max on my tier\n",
-    "    max_tokens=4000,\n",
-    "    top_p=0.1,\n",
-    "    response_format=JsonSchemaFormat(\n",
-    "        name=ReadmeRecommendation.__name__,\n",
-    "        schema=ReadmeRecommendation.model_json_schema(),\n",
-    "        description=\"Structured output for recommendations about possible README updates\",\n",
-    "        strict=True\n",
-    "    )\n",
-    ")\n",
+    "# models_to_try = [\n",
+    "#     \"Llama-3.3-70B-Instruct\",\n",
+    "#     \"Meta-Llama-3.1-405B-Instruct\",\n",
+    "#     \"gpt-4o\",\n",
+    "#     \"gpt-4o-mini\",\n",
+    "#     \"o1-mini\",\n",
+    "#     \"Phi-3.5-MoE-instruct\"\n",
+    "# ]\n",
     "\n",
-    "json_response_message = json.loads(response.choices[0].message.content)\n",
     "\n",
-    "print(response.choices[0].message.content)\n"
+    "client = get_client()\n",
+    "recommendation = review_pull_request(\n",
+    "    client,\n",
+    "    \"gpt-4o-mini\",\n",
+    "    repo,\n",
+    "    pr)\n",
+    "\n",
+    "recommendation"
    ]
   },
   {
@@ -504,111 +92,6 @@
    "metadata": {},
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 44,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'choices': [{'finish_reason': 'length', 'index': 0, 'message': {'content': '{\"description\": \"Structured output for the README review task\", \"properties\": {\"should_update\": {\"description\": \"Whether the README should be updated or not\", \"title\": \"Should Update\", \"type\": \"boolean\"}, \"reason\": {\"description\": \"Reason for the recommendation\", \"title\": \"Reason\", \"type\": \"string\"}, \"updated_readme\": {\"anyOf\": [{\"type\": \"string\"}, {\"type\": \"null\"}], \"default\": null, \"description\": \"Updated README content, required if should_update is True, otherwise optional\", \"title\": \"Updated Readme\"}}, \"required\": [\"should_update\", \"reason\"], \"title\": \"ReadmeRecommendation\", \"type\": \"object\"}\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n \\n\\n\\n\\n\\n \\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n \\n\\n\\n\\n\\n\\n \\n', 'role': 'assistant', 'tool_calls': None}}], 'created': 1736982668, 'id': 'cmpl-00e6457f-2bcd-42c1-bec5-d1f9de115dd6', 'model': 'Llama-3.3-70B-Instruct', 'object': 'chat.completion', 'usage': {'completion_tokens': 4000, 'prompt_tokens': 1924, 'total_tokens': 5924}}"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<class 'azure.ai.inference.models._patch.ChatCompletions'>"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "from pprint import pprint\n",
-    "\n",
-    "type(response)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Model: Llama-3.3-70B-Instruct\n",
-      "Usage: {'completion_tokens': 4000, 'prompt_tokens': 1924, 'total_tokens': 5924}\n",
-      "Finish reason: CompletionsFinishReason.TOKEN_LIMIT_REACHED\n"
-     ]
-    }
-   ],
-   "source": [
-    "# Things that are useful to check\n",
-    "print(f\"Model: {response.model}\")\n",
-    "print(f\"Usage: {response.usage}\")\n",
-    "\n",
-    "choice = response.choices[0]\n",
-    "print(f\"Finish reason: {choice.finish_reason}\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'choices': [{'finish_reason': 'stop', 'index': 0, 'message': {'content': '## Task Output\\n\\nA) **should_update**: No\\nB) **reason**: The pull request introduces a minor change to the Google Play scraping functionality, which does not significantly alter the project\\'s features or requirements. The existing README already documents the project\\'s purpose, functionality, and goals, and the change does not warrant a major update.\\nC) **updated_readme**: Not applicable, as no update is recommended.\\n\\nHowever, it\\'s worth noting that the README could be improved in some areas, such as:\\n\\n* Adding more details about the project\\'s goals and motivations\\n* Providing a clearer explanation of the project\\'s architecture and technical stack\\n* Including more information about the project\\'s testing and development processes\\n* Updating the \"Note\" section to reflect the project\\'s current status and any plans for future development\\n\\nBut these changes are not directly related to the pull request and would require a more comprehensive review of the project\\'s documentation.', 'role': 'assistant', 'tool_calls': None}}], 'created': 1736981525, 'id': 'cmpl-beeaca99-68cf-4666-81bc-137b38fe08b8', 'model': 'Llama-3.3-70B-Instruct', 'object': 'chat.completion', 'usage': {'completion_tokens': 187, 'prompt_tokens': 1763, 'total_tokens': 1950}}"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "if choice.finish_reason == CompletionFinishReason.STOPPED:\n",
-    "    print(f\"Stop reason: {choice.stop_reason}\")"
-   ]
   }
  ],
  "metadata": {

--- a/uv.lock
+++ b/uv.lock
@@ -213,6 +213,34 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-ai-inference"
+version = "1.0.0b7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/37/233eee0bebbf631d2f911a9f1ebbc3784b100d9bfb84efc275e71c1ea636/azure_ai_inference-1.0.0b7.tar.gz", hash = "sha256:bd912f71f7f855036ca46c9a21439f290eed5e61da418fd26bbb32e3c68bcce3", size = 175883 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/b6/5ba830eddc59f820c654694d476c14a3dd9c1f828ff9b48eb8b21dfd5f01/azure_ai_inference-1.0.0b7-py3-none-any.whl", hash = "sha256:59bb6a9ee62bd7654a69ca2bf12fe9335d7045df95b491cb8b5f9e3791c86175", size = 123030 },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.32.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "six" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/ee/668328306a9e963a5ad9f152cd98c7adad86c822729fd1d2a01613ad1e67/azure_core-1.32.0.tar.gz", hash = "sha256:22b3c35d6b2dae14990f6c1be2912bf23ffe50b220e708a28ab1bb92b1c730e5", size = 279128 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/83/325bf5e02504dbd8b4faa98197a44cdf8a325ef259b48326a2b6f17f8383/azure_core-1.32.0-py3-none-any.whl", hash = "sha256:eac191a0efb23bfa83fddf321b27b122b4ec847befa3091fa736a5c32c50d7b4", size = 198855 },
+]
+
+[[package]]
 name = "babel"
 version = "2.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -742,6 +770,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/4c/dab2a281b07596a5fc220d49827fe6c794c66f1493d7a74f1df0640f2cc5/ipywidgets-8.1.5.tar.gz", hash = "sha256:870e43b1a35656a80c18c9503bbf2d16802db1cb487eec6fab27d683381dde17", size = 116723 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/2d/9c0b76f2f9cc0ebede1b9371b6f317243028ed60b90705863d493bae622e/ipywidgets-8.1.5-py3-none-any.whl", hash = "sha256:3290f526f87ae6e77655555baba4f36681c555b8bdbbff430b70e52c34c86245", size = 139767 },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320 },
 ]
 
 [[package]]
@@ -2440,6 +2477,7 @@ name = "update-your-readme"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "azure-ai-inference" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },
@@ -2459,6 +2497,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-ai-inference" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-openai" },


### PR DESCRIPTION
This makes it much easier to try out this Github Action because now the caller doesn't need to setup a separate API key and configure it in Github Secrets. Instead, it uses the caller's github token to call github models.

Upsides:

- No extra API key
- No need to setup Github Secrets
- Might work for forks, which were incompatible with secrets

Downsides:

- Lost support for Anthropic models, and may never regain them because Anthropic is partnered with AWS and Github is a part of Microsoft.
- Possibly lost support for the o1 family, if Langchain was converting the prompts into the right format automatically. The Azure AI inference library doesn't convert to the o1 format and I haven't implemented it yet
